### PR TITLE
Fix github connection and install errors

### DIFF
--- a/app/lib/stores/settings.ts
+++ b/app/lib/stores/settings.ts
@@ -30,7 +30,7 @@ export interface Shortcuts {
 }
 
 export const URL_CONFIGURABLE_PROVIDERS = ['Ollama', 'LMStudio', 'OpenAILike'];
-export const LOCAL_PROVIDERS = ['OpenAILike', 'LMStudio', 'Ollama'];
+export const LOCAL_PROVIDERS = ['OpenAILike', 'LMStudio'];
 
 export type ProviderSetting = Record<string, IProviderConfig>;
 


### PR DESCRIPTION
Enable Ollama provider by default to make its models visible in the dropdown.

Previously, Ollama was listed as a `LOCAL_PROVIDER` and thus disabled by default, preventing its installed models (e.g., `stable-code:3b`) from appearing in the application's model selection dropdown. Removing it from `LOCAL_PROVIDERS` ensures it is enabled upon startup.

---
<a href="https://cursor.com/background-agent?bcId=bc-10aa80e7-e30a-4b91-bd60-42eec40d8435">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10aa80e7-e30a-4b91-bd60-42eec40d8435">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

